### PR TITLE
jsonify dictwalker marker is None

### DIFF
--- a/alchemyjsonschema/dictify.py
+++ b/alchemyjsonschema/dictify.py
@@ -177,7 +177,8 @@ def dictify(ob, schema, convert=attribute_of):
 
 
 def jsonify(ob, schema, convert=jsonify_of, registry=jsonify_dict):
-    return DictWalker(schema, convert, getattr, registry=registry)(ob)
+    return DictWalker(schema, convert, getattr, registry=registry,
+                      marker=None)(ob)
 
 
 def normalize(ob, schema, convert=normalize_of, registry=normalize_dict):


### PR DESCRIPTION
I am using the dictify module to manipulate orm objects, and noticed a small issue. Consider the following models:

``` Python
class User(SABase):
    """A User"""
    __tablename__ = "user"
    __name__ = "user"

    id = sa.Column(sa.Integer, sa.Sequence('user_id_seq'), primary_key=True,
                   doc="primary key")
    createtime = sa.Column(sa.DateTime(), default=datetime.datetime.utcnow)
    address = sa.Column(sa.String(36), unique=True, nullable=False)
    username = sa.Column(sa.String(37), unique=True, nullable=False)

    def __repr__(self):
        return "<User(id=%s, username='%s', email='%s')>" % (
            self.id, self.username, self.address)


class UserKey(SABase):
    """A User's API key"""
    __tablename__ = "user_key"
    __name__ = "user_key"

    key = sa.Column(sa.Integer, sa.Sequence('user_id_seq'), primary_key=True, 
                    doc="primary key")
    createtime = sa.Column(sa.DateTime(), default=datetime.datetime.utcnow)
    deactivated_at = sa.Column(sa.DateTime(), nullable=True)
    user_id = sa.Column("user_id", sa.ForeignKey("user.id"), nullable=False)
    permissionbits = sa.Column(sa.BigInteger, nullable=True)
    keytype = sa.Column(sa.String(36), nullable=False)

    def __repr__(self):
        return "<UserKey(user_id=%s, keytype='%s')>" % (self.user_id,
                                                        self.keytype)
```

Now, if I try to jsonify an instance of a UserKey which does not have deactivated_at, I would expect the return to have no deactivated_at key set. Instead it has a value of None, which cases jsonschema.validate() to fail.

By adding a marker of None to jsonify, objects that do not have an attribute of the name given will ignore that name instead of marking it None. This is because of the last line of jsonify_of.

```
def jsonify_of(ob, name, type_, registry=jsonify_dict):
    try:
        convert_fn = registry[type_]
    except KeyError:
        raise ConvertionError(name, "convert {} failure. unknown format {} of {}".format(name, type_, ob))
    return convert_fn(getattr(ob, name, None))  # if defaulting to None, mark 'ignore'
```
