### PR TITLE
Module input and file output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,23 +111,26 @@ help
 
 .. code:: bash
 
-    $ alchemyjsonschema -h
+    $ alchemyjsonschema --help
     usage: alchemyjsonschema [-h]
                              [--walker {noforeignkey,foreignkey,structual,control}]
-                             [--depth DEPTH]
+                             [--decision {default,comfortable}] [--depth DEPTH]
                              [--decision-relationship DECISION_RELATIONSHIP]
                              [--decision-foreignkey DECISION_FOREIGNKEY]
-                             model
+                             [--out-dir OUT_DIR]
+                             target
 
     positional arguments:
-      model
+      target                the module or class to extract schemas from
 
     optional arguments:
       -h, --help            show this help message and exit
       --walker {noforeignkey,foreignkey,structual,control}
+      --decision {default,comfortable}
       --depth DEPTH
       --decision-relationship DECISION_RELATIONSHIP
       --decision-foreignkey DECISION_FOREIGNKEY
+      --out-dir OUT_DIR
 
 target models
 

--- a/alchemyjsonschema/command.py
+++ b/alchemyjsonschema/command.py
@@ -1,4 +1,5 @@
 # -*- coding:utf-8 -*-
+import inspect
 import sys
 import pkg_resources
 import json
@@ -48,25 +49,64 @@ def detect_decision(x):
         raise Exception(x)
 
 
-def run(model, walker, depth=None, relation_decision=None):
+def write_output_file(schema, model, outdir):
+    fname = model.__tablename__ + ".json"
+    schemaf = outdir + "/" + fname
+    f = open(schemaf, 'w')
+    f.write(schema)
+    f.close()
+
+
+def handle_output(schema, model, outdir=None):
+    if outdir is None:
+        print(schema)
+    else:
+        write_output_file(schema, model, outdir)
+
+
+def run(walker, model=None, module=None, depth=None,
+        relation_decision=None, outdir=None):
     make_schema = SchemaFactory(walker, relation_decision=relation_decision)
-    schema = make_schema(model, depth=depth)
-    print(json.dumps(schema, indent=2, ensure_ascii=False))
+
+    if model is not None:
+        # default behavior
+        schema = make_schema(model, depth=depth)
+        handle_output(json.dumps(schema, indent=2, ensure_ascii=False),
+                      model, outdir=outdir)
+    elif module is not None:
+        # iterate over attributes of module looking for orm objects
+        for name in module.__all__:
+            basemodel = getattr(module, name)
+            schema = make_schema(basemodel, depth=depth)
+            handle_output(json.dumps(schema, indent=2, ensure_ascii=False),
+                          basemodel, outdir=outdir)
+    else:
+        print "Error: Target was neither a model nor a module."
 
 
 def main(sys_args=sys.argv[1:]):
     parser = argparse.ArgumentParser()
-    parser.add_argument("model")
+    parser.add_argument("target", help='the module or class to extract schemas from')
     parser.add_argument("--walker", choices=["noforeignkey", "foreignkey", "structual", "control"], default="structual")
     parser.add_argument("--decision", choices=["default", "comfortable"], default="default")
     parser.add_argument("--depth", default=None, type=int)
     parser.add_argument("--decision-relationship", default="")
     parser.add_argument("--decision-foreignkey", default="")
+    parser.add_argument("--out-dir", default=None)
     args = parser.parse_args(sys_args)
+    model = None
+    module = None
+    rawtarget = import_symbol(args.target)
+    if inspect.isclass(rawtarget):
+        model = rawtarget
+    else:
+        module = rawtarget
     walker = detect_walker(args.walker)
-    model = import_symbol(args.model)
     if walker == HandControlledWalkerFactory:
         decisions = {k.strip(): "relationship" for k in args.decision_relationship.split(" ")}
         decisions.update({k.strip(): "foreignkey" for k in args.decision_foreignkey.split(" ")})
         walker = walker(decisions)
-    return run(model, walker, depth=args.depth, relation_decision=detect_decision(args.decision))
+    return run(walker, model=model,
+               module=module, depth=args.depth,
+               relation_decision=detect_decision(args.decision),
+               outdir=args.out_dir)


### PR DESCRIPTION
In addition to importing from an individual class, now a module with multiple orm classes can be iterated over. Also, if "--out-dir" is set, then schemas will write to json files named after their __tablename__ instead of printing to stdout.

Finally, be aware that the dictify pull request is also part of this one. https://github.com/podhmo/alchemyjsonschema/pull/3 If there is a conflict, please let me know and I will resubmit.