### PR TITLE
Swagger support

### DIFF
--- a/alchemyjsonschema/dictify.py
+++ b/alchemyjsonschema/dictify.py
@@ -52,6 +52,7 @@ jsonify_dict = {('string', None): maybe_wrap(text_),
                 ('string', 'time',): maybe_wrap(isoformat),
                 ('number', None): maybe_wrap(float),
                 ('integer', None): maybe_wrap(int),
+                ('integer', 'int64'): maybe_wrap(long),  # this isn't precisely enough...
                 ('boolean', None): maybe_wrap(bool),
                 ('string', 'date-time'): maybe_wrap(datetime_rfc3339),
                 ('string', 'date'): maybe_wrap(isoformat0),


### PR DESCRIPTION
This PR allows the CLI to output a single definitions file optionally.

Not sure if others use this project in coordination with [Swagger](http://swagger.io), but they are a good fit. Swagger uses json schemas to specify data that passes across an API.

One thing swagger expects is schemas in a single "definitions" key. As many models may refer to each other, this is a more logical scheme than outputting individual schemas, each with their own "definitions" key, duplicating many definitions.