### PR TITLE
Drop deprecated sqlalchemy Binary type.

### DIFF
--- a/alchemyjsonschema/__init__.py
+++ b/alchemyjsonschema/__init__.py
@@ -53,7 +53,6 @@ default_column_to_schema = {
     t.Date: "string",
     t.Time: "string",  # xxx
     t.LargeBinary: "xxx",
-    t.Binary: "xxx",
     t.Boolean: "boolean",
     t.Unicode: "string",
     t.Concatenable: "xxx",


### PR DESCRIPTION
Binary type has now been dropped entirely from sqlalchemy >= 1.4