### PR TITLE
Pin version of SQLAlchemy below 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except IOError:
     README = CHANGES = ""
 
 install_requires = [
-    "sqlalchemy",
+    "sqlalchemy<2",
     "jsonschema",
     "strict-rfc3339",
     "isodate",  # hmm.


### PR DESCRIPTION
The tool is not currently compatible with SQLAlchemy 2.0; updating the requirements to avoid SQLAlchemy 2.x for now