### PR TITLE
fix: remove unused package strict-rfc3339

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ except IOError:
 install_requires = [
     "sqlalchemy",
     "jsonschema",
-    "strict-rfc3339",
     "isodate",  # hmm.
     "pytz",
     "magicalimport",


### PR DESCRIPTION
The library `strict-rfc3339` is, as far as I could tell, never used, and has never been used. 

The main reason that it should be remove is that it's actually problematic to the licensing of `alchemyjsonschema`. Since `strict-rfc3339` is licensed as GPLv3, `alchemyjsonschema` can technically not be licensed with its current MIT license. From my (non-lawyer) understanding of the license structure, MIT licensed dependencies can be used in GPLv3 works, but not the other way around. 

Since the dependency is not, and has never been, actually used, I would say this isn't a problem, but it does pose a licensing problem when trying to install `alchemyjsonschema` if GPLv3 codebases are not permitted.

All tests pass when running in a fresh virtualenv for both Python3.8 and Python3.11. Happy to run in additional environments if necessary.